### PR TITLE
bug 103683 - Recognize Ubuntu 16.04 LTS

### DIFF
--- a/rpmconf/Build/get_plat_tag.sh
+++ b/rpmconf/Build/get_plat_tag.sh
@@ -149,16 +149,13 @@ if [ -f /etc/lsb-release ]; then
       echo "7${i}"
       exit 0
     fi
-    if [ "$RELEASE" = "jesse" ]; then
+    if [ "$RELEASE" = "jessie" ]; then
       echo "8${i}"
       exit 0
-    else
-      echo "UNKNOWN${i}"
-      exit 0
     fi
+    echo "UNKNOWN${i}"
+    exit 0
   fi
-  echo "DEBIANUNKNOWN${i}"
-  exit 0
 fi
 
 if [ -f /etc/debian_version ]; then

--- a/rpmconf/Build/get_plat_tag.sh
+++ b/rpmconf/Build/get_plat_tag.sh
@@ -153,6 +153,10 @@ if [ -f /etc/lsb-release ]; then
       echo "8${i}"
       exit 0
     fi
+    if [ "$RELEASE" = "stretch" ]; then
+      echo "9${i}"
+      exit 0
+    fi
     echo "UNKNOWN${i}"
     exit 0
   fi

--- a/rpmconf/Build/get_plat_tag.sh
+++ b/rpmconf/Build/get_plat_tag.sh
@@ -135,10 +135,13 @@ if [ -f /etc/lsb-release ]; then
     if [ "$RELEASE" = "trusty" ]; then
       echo "14${i}"
       exit 0
-    else
-      echo "UNKNOWN${i}"
+    fi
+    if [ "$RELEASE" = "xenial" ]; then
+      echo "16${i}"
       exit 0
     fi
+    echo "UNKNOWN${i}"
+    exit 0
   fi
   if [ "$DISTRIBUTOR" = "Debian" ]; then
     echo -n "DEBIAN"


### PR DESCRIPTION
This makes get_plat_tag.sh recognize Ubuntu 16.04 aka xenial.

While I was around I also fixed the detection of Debian 8 aka jessie and added Debian 9 aka stretch.
